### PR TITLE
feat: support credentials profiles

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ async function main() {
     .option('keys', { alias: 'k', describe: 'Which keys to update (to update all keys use --all)', type: 'array' })
     .option('all', { alias: 'A', describe: 'Update all keys', type: 'boolean' })
     .option('config', { alias: 'c', describe: 'Reads options from a configuration file' })
+    .option('profile', { describe: 'AWS credentials profile to use', type: 'string' })
     .option('debug', { type: 'boolean', describe: 'Show debugging information', default: false })
     .option('yes', { type: 'boolean', describe: 'Skip confirmation prompt', default: false, alias: 'y' })
     .example('$0 -s my-secrets --all', 'Updates all secrets from AWS Secrets Manager to the current github repository (region can be omitted by specifying an ARN)')
@@ -32,6 +33,7 @@ async function main() {
     allKeys: argv.all,
     keys: argv.keys,
     confirm: !argv.yes,
+    profile: argv.profile,
   });
 }
 

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -2,8 +2,18 @@ import { spawnSync } from 'child_process';
 import * as readline from 'readline';
 import * as aws from 'aws-sdk';
 
+/**
+ * Options for `getSecret`.
+ */
 export interface SecretOptions {
+  /**
+   * The AWS region to read the secret from.
+   */
   readonly region?: string;
+  /**
+   * Credential profile to use.
+   */
+  readonly profile?: string;
 }
 
 export interface Clients {
@@ -61,7 +71,8 @@ function confirmPrompt(): Promise<boolean> {
 }
 
 async function getSecret(secretId: string, options: SecretOptions = {}): Promise<Secret> {
-  const client = new aws.SecretsManager({ region: options.region });
+  const credentials = options.profile ? new aws.SharedIniFileCredentials({ profile: options.profile }) : undefined;
+  const client = new aws.SecretsManager({ region: options.region, credentials });
   const result = await client.getSecretValue({ SecretId: secretId }).promise();
   let json;
   try {

--- a/src/update-secrets.ts
+++ b/src/update-secrets.ts
@@ -21,6 +21,12 @@ export interface UpdateSecretsOptions {
   readonly region?: string;
 
   /**
+   * Use a profile in the shared credentials file.
+   * @default - default credential resolution
+   */
+  readonly profile?: string;
+
+  /**
    * The full name of the github repository.
    * @default - the current repository
    */
@@ -62,7 +68,7 @@ export async function updateSecrets(options: UpdateSecretsOptions) {
   }
 
   const repository: string = options.repository ?? c.getRepositoryName();
-  const secret = await c.getSecret(options.secret, { region });
+  const secret = await c.getSecret(options.secret, { region, profile: options.profile });
   const keys = options.keys ?? [];
 
   if (typeof(secret.json) !== 'object') {

--- a/test/update-secrets.test.ts
+++ b/test/update-secrets.test.ts
@@ -164,3 +164,14 @@ test('confirm: false can disable interactive confirmation', async () => {
   expect(mocks.confirmPrompt).not.toBeCalled();
   expect(mocks.storeSecret).toBeCalledTimes(Object.keys(secretJson).length);
 });
+
+test('update secrets accepts a profile', async () => {
+  await updateSecrets({
+    clients: mocks,
+    allKeys: true,
+    secret: 'my-secret-name',
+    profile: 'my-profile',
+  });
+
+  expect(mocks.getSecret).toBeCalledWith('my-secret-name', { profile: 'my-profile' });
+});


### PR DESCRIPTION
Allow specifying `--profile` to tell sm2gh-secrets to use a specific credentials profile instead of the default credential resolution.

Resolves #10

