### PR TITLE
feat: add support for GitHub environment secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Options:
 * `-r`, `--repo` - The GitHub full repository name (e.g.
   `cdklabs/aws-secrets-github-sync`). If this is not specified, we will try to resolve the
   repo from the current git settings.
+* `-e`, `--environment` - GitHub environment name to sync secrets to. If specified,
+  secrets will be synced to environment secrets instead of repository secrets.
 * `-R`, `--region` - The AWS region to read the secret from. If this is not
   specified, `AWS_REGION` will be used. If the secret is an ARN, we will resolve
   the region from the ARN.
@@ -82,12 +84,13 @@ You can also specify all options via a configuration file. Here's an example
 ```json
 {
   "secret": "publishing-secrets",
+  "environment": "production",
   "region": "us-east-1",
   "prune": true,
   "keys": [
     "NPM_TOKEN",
     "PROJEN_GITHUB_TOKEN"
-  ],
+  ]
 }
 ```
 
@@ -96,6 +99,18 @@ And then, execute:
 ```shell
 aws-secrets-github-sync -C secrets.json
 ```
+
+### Environment Secrets
+
+To sync secrets to a GitHub environment instead of repository secrets, use the
+`--environment` (or `-e`) option:
+
+```shell
+aws-secrets-github-sync -s SECRET -e production --all
+```
+
+This will sync all keys from the AWS Secrets Manager secret to the "production"
+environment secrets in your GitHub repository.
 
 ## Auditing
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ async function main() {
     .option('prune', { type: 'boolean', describe: 'Remove old keys from GitHub', default: false })
     .option('yes', { type: 'boolean', describe: 'Skip confirmation prompt', default: false, alias: 'y' })
     .option('keep', { type: 'array', describe: 'Keep these keys in GitHub (can be used multiple times)', default: [] })
+    .option('environment', { alias: 'e', type: 'string', describe: 'GitHub environment name to sync secrets to (syncs to environment secrets instead of repository secrets)' })
     .example('$0 -s my-secrets --all', 'Updates all secrets from AWS Secrets Manager to the current github repository (region can be omitted by specifying an ARN)')
     .example('$0 -s my-secrets -k TWINE_USERNAME -k TWINE_PASSWORD', 'Only updates two secrets')
     .example('$0 -c sm2gh.json', 'Read settings from sm2gh.json')
@@ -39,6 +40,7 @@ async function main() {
     prune: argv.prune,
     profile: argv.profile,
     keep: argv.keep.map(String),
+    environment: argv.environment,
   });
 }
 

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -65,9 +65,9 @@ export interface Clients {
   getSecret(secretId: string, options?: SecretOptions): Promise<Secret>;
   confirmPrompt(): Promise<boolean>;
   getRepositoryName(): Promise<string>;
-  storeSecret(repository: string, key: string, value: string): Promise<void>;
-  listSecrets(repository: string): Promise<string[]>;
-  removeSecret(repository: string, key: string): Promise<void>;
+  storeSecret(repository: string, key: string, value: string, environment?: string): Promise<void>;
+  listSecrets(repository: string, environment?: string): Promise<string[]>;
+  removeSecret(repository: string, key: string, environment?: string): Promise<void>;
   log(text?: string): void;
 }
 
@@ -97,13 +97,20 @@ async function getRepositoryName(): Promise<string> {
   }
 }
 
-async function storeSecret(repository: string, name: string, value: string): Promise<void> {
-  const args = ['secret', 'set', '--repo', repository, name];
+async function storeSecret(repository: string, name: string, value: string, environment?: string): Promise<void> {
+  const args = ['secret', 'set', '--repo', repository];
+  if (environment) {
+    args.push('--env', environment);
+  }
+  args.push(name);
   await spawnWithRetry(['gh', ...args], { input: value });
 }
 
-async function listSecrets(repository: string): Promise<string[]> {
+async function listSecrets(repository: string, environment?: string): Promise<string[]> {
   const args = ['secret', 'list', '--repo', repository];
+  if (environment) {
+    args.push('--env', environment);
+  }
   const result = await spawnWithRetry(['gh', ...args]);
   const stdout = result.stdout.trim();
   if (!stdout) {
@@ -112,8 +119,12 @@ async function listSecrets(repository: string): Promise<string[]> {
   return stdout.split('\n').map((line: string) => line.split('\t')[0]);
 }
 
-async function removeSecret(repository: string, key: string): Promise<void> {
-  const args = ['secret', 'remove', '--repo', repository, key];
+async function removeSecret(repository: string, key: string, environment?: string): Promise<void> {
+  const args = ['secret', 'remove', '--repo', repository];
+  if (environment) {
+    args.push('--env', environment);
+  }
+  args.push(key);
   await spawnWithRetry(['gh', ...args]);
 }
 


### PR DESCRIPTION
Adds support for syncing secrets to GitHub environment secrets instead of repository secrets.

## Changes

- Add `--environment` (`-e`) CLI option to specify target environment
- Update GitHub CLI commands to use `--env` flag when environment is specified
- Add environment parameter to all secret management functions
- Update documentation with environment secrets usage examples
- Update tests to handle the new environment parameter

## Usage

```shell
# Sync to environment secrets
aws-secrets-github-sync -s SECRET -e production

# Still works for repository secrets (default behavior)
aws-secrets-github-sync -s SECRET
```